### PR TITLE
Allow beberlei/assert from 2.0 onwards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "beberlei/assert": "^3.2",
+        "beberlei/assert": ">=2.0",
         "lstrojny/functional-php": "^1.9",
         "ext-mbstring": "*"
     },


### PR DESCRIPTION
Only two asserts are used and they don't change between 2.0 and 3.0.